### PR TITLE
update requirements.txt and data pipeline for quick reproduction of results

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,18 @@ pip install -r requirements.txt
 # Data Preparation
 Download and extract Tiny ImageNet at [https://image-net.org/](https://image-net.org/) in the home directory of this repository.
 
+Stanford hosts a copy that works to reproduce the results of this repo. For example, from the home directory of this project run in terminal
+
+```
+wget http://cs231n.stanford.edu/tiny-imagenet-200.zip
+```
+
+and extract the contents to the home directory
+
+```
+unzip tiny-imagenet-200.zip && mv tiny-imagenet-200/* . && rmdir tiny-imagenet-200
+```
+
 Then run `python fileio.py` to format the data. This will convert the images into tensors and pickle them into two files, `train_dataset.pkl` and `val_dataset.pkl` that will be used in the main code.
 
 # Training

--- a/fileio.py
+++ b/fileio.py
@@ -18,7 +18,7 @@ pickle_data()    # pickle the dataset for fast reading
 
 def get_label_mapping():
     object_mapping = pd.read_csv('words.txt', sep='\t', index_col=0, names=['label'])
-    labels_str = [f.name for f in os.scandir('train') if f.is_dir()]
+    labels_str = sorted([f.name for f in os.scandir('train') if f.is_dir()])
     labels = pd.DataFrame(labels_str, columns=['id'])
     labels['label'] = [object_mapping.loc[ids].item() for ids in labels['id']]
 
@@ -26,7 +26,7 @@ def get_label_mapping():
 
 def get_train_data(one_hot=False):
     train_data = torch.Tensor().type(torch.ByteTensor)
-    labels_str = [f.name for f in os.scandir('train') if f.is_dir()]
+    labels_str = sorted([f.name for f in os.scandir('train') if f.is_dir()])
     labels = []
     i = 1
     for root, dirs, files in os.walk('train'):
@@ -49,7 +49,7 @@ def get_train_data(one_hot=False):
 
 def get_val_data(one_hot=False):
     val_data = torch.Tensor().type(torch.ByteTensor)
-    labels_str = [f.name for f in os.scandir('train') if f.is_dir()]
+    labels_str = sorted([f.name for f in os.scandir('train') if f.is_dir()])
     labels = []
     val_annotations = pd.read_csv('val/val_annotations.txt', sep='\t', names=['filename', 'label_str', 'x_min', 'y_min', 'x_max', 'y_max'])
     num_imgs = len(os.listdir('val/images'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
+torch>=2.0.0
+torchvision>=0.15.0
 timm==0.6.7
---extra-index-url https://download.pytorch.org/whl/cu116
-torch==1.12.1
-torchvision==0.13.1
-
+datasets
+huggingface_hub
 opencv-python
 pandas
 numpy


### PR DESCRIPTION
thx for the repo and weights

made a few tweaks to actually reproduce results in 2025 quickly(:

1. updated requirements.txt so you can i) actually install dependencies (late 2025) while ii) still being able to reproduce the results
2. updated README.md to give example how to quickly wget tinyimagenet from stanford hosted blob
3. updated fileio.py data prep, in particular the label mapping, with `sorted([f.name for f in os.scandir('train') if f.is_dir()])` instead of standalone `os.scandir` since it does not behave consistently -> leading to label noise -> leading to nonsense results


